### PR TITLE
add OS flag for OAIGen

### DIFF
--- a/flatten_name.go
+++ b/flatten_name.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -112,6 +113,10 @@ func uniqifyName(definitions spec.Definitions, name string) (string, bool) {
 	}
 
 	if len(definitions) == 0 {
+		return name, isOAIGen
+	}
+
+	if strings.EqualFold(os.Getenv("OAIGEN_DEDUPE"), "false") {
 		return name, isOAIGen
 	}
 


### PR DESCRIPTION
This env var allows us to prevent the creation of OAIGen suffixed names in situations where there are complex schemas with no conflicting duplicates but loading seems non-deterministic causing problems in false positive "missing" elements.